### PR TITLE
ensure_frontend_package: add react-debounce-input

### DIFF
--- a/example/pcconfig.py
+++ b/example/pcconfig.py
@@ -4,7 +4,5 @@ config = pc.Config(
     app_name="example",
     db_url="sqlite:///pynecone.db",
     env=pc.Env.DEV,
-    frontend_packages=[
-        "react-debounce-input@3.3.0",
-    ],
+    frontend_packages=[],
 )

--- a/src/pynecone_debounce_input.py
+++ b/src/pynecone_debounce_input.py
@@ -48,3 +48,17 @@ debounce_input = DebounceInput.create
 def props_not_none(c: pc.Component) -> dict[str, Any]:
     cdict = {a: getattr(c, a) for a in c.get_props() if getattr(c, a, None) is not None}
     return cdict
+
+
+def ensure_frontend_package():
+    from pynecone.config import get_config
+
+    config = get_config()
+    for frontend_package in config.frontend_packages:
+        if frontend_package.partition("@")[0].strip() == "react-debounce-input":
+            return
+    config.frontend_packages.append("react-debounce-input")
+
+
+# ensure that all users of this module have it available
+ensure_frontend_package()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,14 +1,74 @@
 from pathlib import Path
+import shutil
 import subprocess
+import sys
+from unittest import mock
 
+import pynecone.config
 import pytest
+
+import pynecone_debounce_input
 
 
 @pytest.fixture
-def example_project():
-    return Path(__file__).resolve().parents[1] / "example"
+def example_project(tmp_path):
+    project_dir = Path(__file__).resolve().parents[1] / "example"
+    tmp_project_dir = tmp_path / "example"
+    shutil.copytree(project_dir, tmp_project_dir)
+    return tmp_project_dir
 
 
-def test_export_example(example_project):
+@pytest.fixture(params=[True, False], ids=["pin_deps", "no_deps"])
+def pin_deps(request, example_project):
+    if request.param:
+        new_config = []
+        for config_line in (
+            (example_project / "pcconfig.py").read_text().splitlines(True)
+        ):
+            new_config.append(
+                config_line.replace(
+                    "frontend_packages=[]",
+                    "frontend_packages=['react-debounce-input@3.3.0']",
+                )
+            )
+        (example_project / "pcconfig.py").write_text("".join(new_config))
+    return request.param
+
+
+def test_export_example(example_project, pin_deps):
     _ = subprocess.run(["pc", "init"], cwd=example_project, check=True)
+    # hack to ensure frontend packages get generated pynecone-io/pynecone#814
+    _ = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import pynecone_debounce_input; "
+            "from pynecone.utils.prerequisites import install_frontend_packages as f; f('.web')",
+        ],
+        cwd=example_project,
+        check=True,
+    )
     _ = subprocess.run(["pc", "export"], cwd=example_project, check=True)
+    assert (example_project / "frontend.zip").exists()
+    assert (example_project / "backend.zip").exists()
+
+
+@pytest.mark.parametrize(
+    ("frontend_packages", "exp_frontend_packages"),
+    [
+        ([], ["react-debounce-input"]),
+        (["react-debounce-input"], ["react-debounce-input"]),
+        (["react-debounce-input@3.3.0"], ["react-debounce-input@3.3.0"]),
+        (
+            ["foo", "react-debounce-input@3.3.0", "bar"],
+            ["foo", "react-debounce-input@3.3.0", "bar"],
+        ),
+        (["foo", "bar"], ["foo", "bar", "react-debounce-input"]),
+    ],
+)
+def test_ensure_frontend_package(monkeypatch, frontend_packages, exp_frontend_packages):
+    config = pynecone.config.get_config()
+    config.frontend_packages = frontend_packages
+    monkeypatch.setattr(pynecone.config, "get_config", mock.Mock(return_value=config))
+    pynecone_debounce_input.ensure_frontend_package()
+    assert config.frontend_packages == exp_frontend_packages


### PR DESCRIPTION
if react-debounce-input is not already in the `Config.frontend_packages` list, then append it.

Fix tests to actually check for the presence of backend.zip and frontend.zip (before the export was failing, the tests just didn't notice it).